### PR TITLE
Fixes #157 line_width has no effect due to stroke_opacity

### DIFF
--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -25,6 +25,9 @@ class Gruff::Line < Gruff::Base
   attr_accessor :line_width
   attr_accessor :dot_radius
 
+  # Opacity of the lines' stroke
+  attr_accessor :line_stroke_opacity
+
   # default is a circle, other options include square
   attr_accessor :dot_style
 
@@ -242,7 +245,7 @@ class Gruff::Line < Gruff::Base
         # Reset each time to avoid thin-line errors
         @d = @d.stroke data_row[DATA_COLOR_INDEX]
         @d = @d.fill data_row[DATA_COLOR_INDEX]
-        @d = @d.stroke_opacity 1.0
+        @d = @d.stroke_opacity line_stroke_opacity || 1.0 # transparent if not set
         @d = @d.stroke_width line_width ||
                                  clip_value_if_greater_than(@columns / (@norm_data.first[DATA_VALUES_INDEX].size * 4), 5.0)
 


### PR DESCRIPTION
- fixed line_width option in Line (stroke_opacity was set to 1.0 so line_width had no effect)
- added 'line_stroke_opacity' parameter to control imagemagick's stroke-opacity option (defaults to 1.0 – transparent)
